### PR TITLE
fix failling test for pandas 0.25

### DIFF
--- a/aikit/tools/data_structure_helper.py
+++ b/aikit/tools/data_structure_helper.py
@@ -104,7 +104,10 @@ def convert_to_array(xx, mapped_type=None):
             return xx
 
     elif mapped_type == DataTypes.SparseArray:
-        return np.array(xx.todense())  # np.array to prevent type 'matrix'
+        if xx.dtype == np.object:
+            return np.array(xx.astype(np.float64).todense())
+        else:
+            return np.array(xx.todense())  # np.array to prevent type 'matrix'
 
     elif mapped_type == DataTypes.SparseDataFrame:
         return xx.to_dense().values
@@ -521,7 +524,12 @@ def generic_hstack(all_datas, output_type=None, all_columns_names=None):
             return convert_to_sparsearray(all_datas[0])
 
         else:
-            return sparse.hstack([convert_to_sparsearray(data) for data in all_datas])
+            all_sparse_data = [convert_to_sparsearray(data) for data in all_datas]
+            for i, data in enumerate(all_sparse_data):
+                if data.dtype == np.object:
+                    all_sparse_data[i] = data.astype(np.float64)
+                
+            return sparse.hstack(all_sparse_data)
 
     elif output_type == DataTypes.SparseDataFrame:
 

--- a/aikit/transformers/target.py
+++ b/aikit/transformers/target.py
@@ -171,6 +171,9 @@ class _TargetEncoderBase(TransformerMixin, BaseEstimator):
         return result_serie
 
     def fit(self, X, y):
+        
+        if y is None:
+            raise ValueError("I need a value for 'y'")
 
         self._random_gen = check_random_state(self.random_state)
 
@@ -247,6 +250,9 @@ class _TargetEncoderBase(TransformerMixin, BaseEstimator):
 
     def fit_transform(self, X, y):
 
+        if y is None:
+            raise ValueError("I need a value for 'y'")
+        
         if not isinstance(y, pd.Series):
             sy = pd.Series(y)
         else:

--- a/tests/transformers/test_all_transformers.py
+++ b/tests/transformers/test_all_transformers.py
@@ -913,6 +913,19 @@ def verif_CategoricalEncoder():
 # import aikit.transformers_target
 # reload(aikit.transformers_target)
 
+@pytest.mark.parametrize("cv, noise_level, smoothing_value", list(itertools.product((None, 10), (None, 0.1), (0, 1))))
+def test_TargetEncoderClassifier_fails_no_y(cv, noise_level, smoothing_value):
+    
+    enc_kwargs = {
+        "columns_to_use": variable_by_type["NUM"] + variable_by_type["CAT"],
+        "cv": cv,
+        "noise_level": noise_level,
+        "smoothing_value": smoothing_value,
+    }
+    model = TargetEncoderClassifier(**enc_kwargs)
+    with pytest.raises(ValueError):
+        model.fit(df1) # raise because no target
+
 
 @pytest.mark.longtest
 @pytest.mark.parametrize("cv, noise_level, smoothing_value", list(itertools.product((None, 10), (None, 0.1), (0, 1))))
@@ -973,7 +986,7 @@ def test_TargetEncoderClassifier3(cv, noise_level, smoothing_value):
         klass=TargetEncoderClassifier,
         enc_kwargs=enc_kwargs3,
         all_types=(DataTypes.DataFrame, DataTypes.SparseDataFrame),  # DataTypes.NumpyArray),
-        additional_test_functions=[check_all_numerical, check_no_null, check_between_01, nb_columns_verify(3)],
+        additional_test_functions=[check_all_numerical, check_no_null, check_between_01, nb_columns_verify(5)],
         randomized_transformer=noise_level is not None,
         difference_tolerence=1.0,
         difference_fit_transform=(noise_level is not None) or (cv is not None)
@@ -1051,7 +1064,7 @@ def test_TargetEncoderClassifierEntropy3(cv, noise_level, smoothing_value):
         klass=TargetEncoderEntropyClassifier,
         enc_kwargs=enc_kwargs3,
         all_types=(DataTypes.DataFrame, DataTypes.SparseDataFrame),  # DataTypes.NumpyArray),
-        additional_test_functions=[check_all_numerical, check_no_null, check_positive, nb_columns_verify(3)],
+        additional_test_functions=[check_all_numerical, check_no_null, check_positive, nb_columns_verify(5)],
         randomized_transformer=noise_level is not None,
         difference_tolerence=1.0,
         difference_fit_transform=(noise_level is not None) or (cv is not None)
@@ -1162,7 +1175,7 @@ def test_TargetEncoderRegressor3(cv, noise_level, smoothing_value):
         klass=TargetEncoderRegressor,
         enc_kwargs=enc_kwargs3,
         all_types=(DataTypes.DataFrame, DataTypes.SparseDataFrame),  # DataTypes.NumpyArray),
-        additional_test_functions=[check_all_numerical, check_no_null, nb_columns_verify(3)],
+        additional_test_functions=[check_all_numerical, check_no_null, nb_columns_verify(5)],
         randomized_transformer=randomized_transformer,  # noise_level is not None ,
         difference_tolerence=difference_tolerence,  # 0.5,
         difference_fit_transform=(noise_level is not None) or (cv is not None)

--- a/tests/transformers/test_all_transformers.py
+++ b/tests/transformers/test_all_transformers.py
@@ -162,6 +162,10 @@ def verif_conversion(df, dont_test_sparse_array=False):
                 assert temp_conversion3 is temp_conversion
 
             test_conversion4 = convert_generic(temp_conversion3, output_type=DataTypes.NumpyArray)
+            assert get_type(test_conversion4) == DataTypes.NumpyArray
+            #if output_type == DataTypes.SparseDataFrame and output_type2 == DataTypes.SparseArray:
+            #    assert _array_almost_equal(test_conversion4, df.values, tolerance=10**(-4))
+            #else:
             assert _array_equal(test_conversion4, df.values)
 
 
@@ -200,9 +204,9 @@ def test_to_coo_sparse_matrix_bug():
 
 
 def test_conversion():
-    verif_conversion(X_train.loc[:, variable_by_type["NUM"]])
-    verif_conversion(X_train_shuffled.loc[:, variable_by_type["NUM"]])
-    verif_conversion(X_test.loc[:, variable_by_type["NUM"]])
+    verif_conversion(X_train.loc[:, variable_by_type["NUM"]], dont_test_sparse_array=True)
+    verif_conversion(X_train_shuffled.loc[:, variable_by_type["NUM"]],dont_test_sparse_array=True)
+    verif_conversion(X_test.loc[:, variable_by_type["NUM"]],dont_test_sparse_array=True)
 
     verif_conversion(X_train.loc[:, variable_by_type["CAT"]], dont_test_sparse_array=True)
     verif_conversion(X_train_shuffled.loc[:, variable_by_type["CAT"]], dont_test_sparse_array=True)
@@ -212,6 +216,10 @@ def test_conversion():
     verif_conversion(X_train_shuffled, dont_test_sparse_array=True)
     verif_conversion(X_test, dont_test_sparse_array=True)
 
+def test_conversion_sparse_array():
+    verif_conversion(X_train.loc[:, variable_by_type["NUM"]], dont_test_sparse_array=False)
+    verif_conversion(X_train_shuffled.loc[:, variable_by_type["NUM"]],dont_test_sparse_array=False)
+    verif_conversion(X_test.loc[:, variable_by_type["NUM"]],dont_test_sparse_array=False)
 
 # In[] : test concatenation
 
@@ -307,9 +315,9 @@ def verif_generic_hstack(df, dont_test_sparse_array=False, split_index=4):
 
 
 def test_generic_hstack():
-    verif_generic_hstack(X_train.loc[:, variable_by_type["NUM"]], split_index=4)
-    verif_generic_hstack(X_train_shuffled.loc[:, variable_by_type["NUM"]], split_index=4)
-    verif_generic_hstack(X_test.loc[:, variable_by_type["NUM"]], split_index=4)
+    verif_generic_hstack(X_train.loc[:, variable_by_type["NUM"]], split_index=4, dont_test_sparse_array=True)
+    verif_generic_hstack(X_train_shuffled.loc[:, variable_by_type["NUM"]], split_index=4, dont_test_sparse_array=True)
+    verif_generic_hstack(X_test.loc[:, variable_by_type["NUM"]], split_index=4,dont_test_sparse_array=True)
 
     verif_generic_hstack(X_train.loc[:, variable_by_type["CAT"]], dont_test_sparse_array=True, split_index=2)
     verif_generic_hstack(X_train_shuffled.loc[:, variable_by_type["CAT"]], dont_test_sparse_array=True, split_index=2)
@@ -319,6 +327,10 @@ def test_generic_hstack():
     verif_generic_hstack(X_train_shuffled, dont_test_sparse_array=True)
     verif_generic_hstack(X_test, dont_test_sparse_array=True)
 
+def test_generic_hstack_sparse():
+    verif_generic_hstack(X_train.loc[:, variable_by_type["NUM"]], split_index=4, dont_test_sparse_array=False)
+    verif_generic_hstack(X_train_shuffled.loc[:, variable_by_type["NUM"]], split_index=4, dont_test_sparse_array=False)
+    verif_generic_hstack(X_test.loc[:, variable_by_type["NUM"]], split_index=4,dont_test_sparse_array=False)
 
 # In[] : Categorical Encoder
 


### PR DESCRIPTION
fix failling test for pandas 0.25 : change conversion sparse to dense when dtype == object