### PR TITLE
Allow some transformers to be used only by a subset of models

### DIFF
--- a/aikit/ml_machine/ml_machine.py
+++ b/aikit/ml_machine/ml_machine.py
@@ -1086,14 +1086,14 @@ class RandomModelGenerator(object):
 
         Parameters
         ----------
-        * needed_steps : list of dictionnary representing each step, each one with a 'step' key and an 'optional' key
+        * needed_steps : list of dictionaries representing each step, each one with a 'step' key and an 'optional' key
 
         * models_to_keep : list of models that we want to draw within
 
         * log_unif : bool, default = True
             if True (and random_probas is not None), will draw a model with probability proportionnal to 'log(1 + hyperparameter.size)'
 
-        * random_probas : dictionnary of proba array for each step or None
+        * random_probas : dictionary of proba array for each step or None
             if None will use uniform (or log_uniform) otherwise will draw according to that probability
 
 

--- a/aikit/ml_machine/ml_machine.py
+++ b/aikit/ml_machine/ml_machine.py
@@ -50,6 +50,7 @@ from aikit.ml_machine.steps_handling import (
 from aikit.ml_machine.hyper_parameters import HyperMultipleChoice, HyperCrossProduct, HyperComposition
 
 from aikit.ml_machine.ml_machine_registration import MODEL_REGISTER
+from aikit.ml_machine.model_registrer import allow_conditional
 from aikit.ml_machine.data_persister import SavingType
 from aikit.ml_machine.jobs import AbstractJobRunner
 from aikit.ml_machine.model_graph import convert_graph_to_code
@@ -1098,12 +1099,16 @@ class RandomModelGenerator(object):
 
 
         """
+        
+        needed_steps_reordered = sorted(needed_steps, key=lambda step:MODEL_REGISTER._drawing_order.get(step["step"], -1))
+        
+        
         # TODO : specify a random_state + save random state ?
         # TODO : allow conditionnal probas to draw steps  => create a Graphical Proba Model to handle implication
-        models_by_steps = OrderedDict()
-        for step in needed_steps:
+        models_by_steps_reordered = OrderedDict()
+        for step in needed_steps_reordered:
 
-            all_choices = [n for n in models_to_keep if n[0] == step["step"]]
+            all_choices = [n for n in models_to_keep if n[0] == step["step"] and allow_conditional(model=n, models_by_steps=models_by_steps_reordered)]
             if step["optional"]:
                 all_choices.append((None, None))
                 # TODO : put that into a Constant
@@ -1135,8 +1140,13 @@ class RandomModelGenerator(object):
             ii = np.arange(len(all_choices))
             chosen_class = all_choices[ii[self.random_state.choice(ii, size=1, p=p)[0]]]
 
-            models_by_steps[step["step"]] = chosen_class
+            models_by_steps_reordered[step["step"]] = chosen_class
             # all_current_steps[chosen_class] = var_type
+
+        # Put everything into the corrected order
+        models_by_steps = OrderedDict()
+        for step in needed_steps:
+            models_by_steps[step["step"]] = models_by_steps_reordered[step["step"]]
 
         return models_by_steps
 

--- a/aikit/ml_machine/ml_machine_registration.py
+++ b/aikit/ml_machine/ml_machine_registration.py
@@ -122,6 +122,7 @@ class ModelRepresentationBase(_AbstractModelRepresentation):
     # * the model has a paramters among that list
     # * the default parameters is not specified within the class (withing 'default_parameters')
 
+    depends_on = ()
 
 ### Linear
 @register

--- a/aikit/ml_machine/model_registrer.py
+++ b/aikit/ml_machine/model_registrer.py
@@ -108,7 +108,7 @@ class _MODEL_REGISTER(object):
                 if has_cycle(self.step_dependencies):
                     raise ValueError(f"adding this dependency {depending_step} -> {category} create a cycle")
 
-                self._drawing_order = {step:n for n, step in iter_graph(self.step_dependencies)}
+                self._drawing_order = {step:n for n, step in enumerate(iter_graph(self.step_dependencies))}
 
         return self
 

--- a/aikit/ml_machine/model_registrer.py
+++ b/aikit/ml_machine/model_registrer.py
@@ -7,9 +7,12 @@ Created on Fri Apr 27 08:38:10 2018
 
 from inspect import signature
 
+import networkx as nx
+
+from aikit.enums import StepCategories
 from aikit.ml_machine import hyper_parameters as hp
 from aikit.model_definition import DICO_NAME_KLASS
-
+from aikit.tools.graph_helper import has_cycle
 
 # In[] : test generic model definition
 def get_init_parameters(klass):
@@ -48,9 +51,18 @@ class _MODEL_REGISTER(object):
         self.default_hyper_parameters = {}
         self.init_parameters = {}
         self.informations = {}
+        self.is_allowed = {}
         self.all_registered = []
+        
+        self.step_dependencies = nx.DiGraph()
 
-    def register_new_class(self, category, klass, hyper=None, default_hyper=None, **kwargs):
+    def register_new_class(self,
+                           category,
+                           klass, hyper=None,
+                           default_hyper=None,
+                           is_allowed=None,
+                           depends_on=None,
+                           **kwargs):
 
         if not isinstance(klass, type):
             raise TypeError("klass should be klass")
@@ -70,6 +82,9 @@ class _MODEL_REGISTER(object):
         if default_hyper is not None:
             self.default_hyper_parameters[key] = default_hyper
 
+        if is_allowed is not None:
+            self.is_allowed[key] = is_allowed
+
         if kwargs:
             self.informations[key] = {k: v for k, v in kwargs.items()}
 
@@ -77,6 +92,21 @@ class _MODEL_REGISTER(object):
             raise ValueError(
                 "You should also register that klass : %s within the 'simple register' file" % klass.__name__
             )
+
+        self.step_dependencies.add_node(category)            
+        if depends_on is not None:
+            if not isinstance(depends_on, (list, tuple, set)):
+                depends_on = (depends_on, )
+                
+            for depending_step in depends_on:
+                if depending_step not in StepCategories.alls:
+                    raise ValueError(f"{depending_step} is not a know step")
+
+                self.step_dependencies.add_edge(depending_step, category)
+                
+                if has_cycle(self.step_dependencies):
+                    raise ValueError(f"adding this dependency {depending_step} -> {category} create a cycle")
+
 
         return self
 
@@ -120,7 +150,14 @@ def register(klass):
     other = {
         k: v
         for k, v in klass.__dict__.items()
-        if not k.startswith("_") and k not in ("name", "klass", "custom_hyper", "default_parameters", "category")
+        if not k.startswith("_") and k not in ("name",
+                                               "klass",
+                                               "custom_hyper",
+                                               "default_parameters",
+                                               "category",
+                                               "is_allowed",
+                                               "depends_on"
+                                               )
     }
 
     if klass.category is None:
@@ -134,6 +171,8 @@ def register(klass):
         klass=klass.klass,
         hyper=klass.get_hyper_parameter(),
         default_hyper=klass.get_default_hyper_parameter(),
+        is_allowed=klass.is_allowed,
+        depends_on=klass.depends_on,
         **other
     )
 
@@ -192,6 +231,36 @@ class _AbstractModelRepresentation(object):
             elif p in cls.default_default_hyper:
                 default_hyper_parameters[p] = cls.default_default_hyper[p]
                 
-        return default_hyper_parameters    
+        return default_hyper_parameters
+    
+    @classmethod
+    def is_allowed(cls, models_by_steps):
+        return True
 
 MODEL_REGISTER = _MODEL_REGISTER()
+
+
+def allow_conditional(model, models_by_steps):
+    """ is a given model allowed to be drawn based on what was already drawn in previous steps
+    
+    Parameters
+    ----------
+    model : 2-uple (name, step)
+        the model that we want to draw
+        
+    models_by_steps : dictionnary of keys = steps, and values = Model
+        the models already included
+
+    Returns
+    -------
+    boolean
+    """
+
+    model_is_allowed_fun = MODEL_REGISTER.is_allowed.get(model, None)
+
+    if model_is_allowed_fun is None:
+        return True
+    
+    return model_is_allowed_fun(models_by_steps)    
+    
+

--- a/aikit/ml_machine/model_registrer.py
+++ b/aikit/ml_machine/model_registrer.py
@@ -12,7 +12,7 @@ import networkx as nx
 from aikit.enums import StepCategories
 from aikit.ml_machine import hyper_parameters as hp
 from aikit.model_definition import DICO_NAME_KLASS
-from aikit.tools.graph_helper import has_cycle
+from aikit.tools.graph_helper import has_cycle, iter_graph
 
 # In[] : test generic model definition
 def get_init_parameters(klass):
@@ -55,6 +55,7 @@ class _MODEL_REGISTER(object):
         self.all_registered = []
         
         self.step_dependencies = nx.DiGraph()
+        self._drawing_order = {}
 
     def register_new_class(self,
                            category,
@@ -107,6 +108,7 @@ class _MODEL_REGISTER(object):
                 if has_cycle(self.step_dependencies):
                     raise ValueError(f"adding this dependency {depending_step} -> {category} create a cycle")
 
+                self._drawing_order = {step:n for n, step in iter_graph(self.step_dependencies)}
 
         return self
 

--- a/aikit/ml_machine/steps_handling.py
+++ b/aikit/ml_machine/steps_handling.py
@@ -26,7 +26,6 @@ def get_needed_steps(df_information, type_of_problem):
 
     needed_steps = []
 
-    # Rmk : pour l'instant il faut positionner ces noeuds au debut
     if is_regression:
         needed_steps.append({"step": en.StepCategories.TargetTransformer, "optional": True})
 

--- a/tests/ml_machine/test_ml_machine.py
+++ b/tests/ml_machine/test_ml_machine.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from sklearn.utils import check_random_state
 
 from aikit.datasets.datasets import load_dataset, DatasetEnum
-from aikit.enums import TypeOfProblem, TypeOfVariables
+from aikit.enums import TypeOfProblem, TypeOfVariables, StepCategories
 from aikit.ml_machine.ml_machine import (
     AutoMlConfig,
     JobConfig,
@@ -30,7 +30,7 @@ from aikit.model_definition import sklearn_model_from_param
 
 from aikit.ml_machine.ml_machine_guider import AutoMlModelGuider
 from aikit.ml_machine.data_persister import FolderDataPersister
-
+from aikit.tools.graph_helper import get_terminal_nodes
 
 def loader(num_only=False):
     if num_only:
@@ -230,10 +230,14 @@ def test_RandomModelGenerator_iterator(type_of_iterator, num_only):
 
     # verif iterator
     for model in iterator:
-        
+
         assert isinstance(model, tuple)
         assert len(model) == 3
         Graph, all_models_params, block_to_use = model
+
+        terminal_nodes = get_terminal_nodes(Graph)
+        assert len(terminal_nodes) == 1
+        assert terminal_nodes[0][0] == StepCategories.Model
         
         #graphviz_graph(Graph)
 


### PR DESCRIPTION
include the possibility to add dependencies between what is drawn by the auto-ml.
Example :

if we have a transformer that we only want to use with one model we can include that dependency when registering the model.
Not used as of now, but will be useful with LGBM and Categories Encoding

(This needs to be rebased but I don't know where...)