### PR TITLE
substitute and add_nodes in GraphPipeline

### DIFF
--- a/aikit/plot.py
+++ b/aikit/plot.py
@@ -174,7 +174,7 @@ def conditional_boxplot(df, var, explaining_var, nb_quantiles=10, use_rank=True,
         [sub_df[var_bis].values for _, sub_df in df_copy.groupby("_quantile")],
         positions=positions,
         widths=widths,
-        manage_xticks=False,
+        manage_ticks=False,
     )
 
     plt.xticks(positions, labels=["%2.2f" % p for p in real_positions])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1137,6 +1137,24 @@ def test_GraphPipeline_substitute_nodes():
         pipeline.substitute_nodes({"pt1": "this_is_not_a_model"})
     
 
+def test_GraphPipeline_add_nodes():
+    
+    pipeline = get_pipeline()
+    
+    new_pipeline = pipeline.add_nodes({"pt0":DebugPassThrough(column_prefix="PT0_", debug=True)}, [("pt0", "pt1")])
+    
+    assert isinstance(new_pipeline, GraphPipeline)
+    Xres= new_pipeline.fit_transform(dfX, y)
+    assert Xres.columns[0] == "PT4__PT3__PT1__PT0__text1"
+    
+    Xres2 = pipeline.fit_transform(dfX)
+    assert Xres2.columns[0] == "PT4__PT3__PT1__text1"
+    
+    with pytest.raises(ValueError):
+        pipeline.add_nodes({"pt1": DebugPassThrough(column_prefix="newPT1_", debug=True)}, new_edges=[("pt0", "pt1")])
+        
+
+        
 def test_GraphPipeline_from_sklearn():
     
     np.random.seed(123)


### PR DESCRIPTION
add two methods to help modify an existing GraphPipeline 
 - substitute_nodes : to remplace some models by other
 - add_nodes : to add models to pipeline